### PR TITLE
Modify docker provisioner to use "docker run --rm" flag.

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -170,7 +170,15 @@ func commonArgs(cluster string, cfg *config.Cluster) ([]string, error) {
 		// retries is 0, so only restart on reboots.
 		// however this _actually_ means the same thing as always
 		// so the closest thing is on-failure:1, which will retry *once*
-		"--restart=on-failure:1",
+		//
+		// Nestybox: skip "--restart" as it conflicts with "--rm". The latter
+		// allows Docker + Sysbox to delete the containers that make up the
+		// cluster much faster. Without "--rm", when a container stops, sysbox
+		// must move some data from host volumes it manages to the container's
+		// rootfs. This can be slow (several seconds per container), and thus
+		// slows down the process of deleting the cluster.
+		//
+		// "--restart=on-failure:1",
 	}
 
 	// enable IPv6 if necessary
@@ -207,7 +215,7 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 
 		// Nestybox: use Sysbox
 		"--runtime=sysbox-runc",
-
+		"--rm",
 		"--hostname", name, // make hostname match container name
 		"--name", name, // ... and set the container name
 		// label the node with the role ID


### PR DESCRIPTION
This change modifies the KinD docker provisioner to use the
Docker auto-remove (i.e., "--rm") flag.

This makes deletion of the containers that make up the KinD
cluster much faster when using Docker + Sysbox. For a 10-node
cluster, the cluster deletion time goes from 30 seconds
to < 5 seconds.

The reason "--rm" helps is the following: when a containers starts, sysbox
creates host volumes that it mounts into the container at specific directories
to avoid the overlayfs-on-overlayfs (not suportted). When the container
stops, sysbox copies data from those host volumes back to the container's
rootfs (where the data belongs).

That copy can take time (many seconds) per container. For a
multi-node KinD cluster, it can quickly add up.

One way to avoid this copy is to use the "docker run --rm" flag. Sysbox
can detect if this flag was used on a container. In this case, Sysbox
can avoid the copy described above, since it knows the container's
rootfs will be deleted anyway. This reduces the container deletion
time significantly, which in turn reduces the cluster deletion
time to a few seconds.

One drawback of this change is that KinD uses the "docker run --restart" flag.
This flag is incompatible with "--rm". Which this change, we remove the
"--restart" flag, which means the KinD cluster won't come up if/when
the docker daemon restarts.

We think this drawback is less severe than the problem that this
change solves.