### PR TITLE
Allow kind-sysbox compilation when operating in docker's userns-remap mode

### DIFF
--- a/hack/go_container.sh
+++ b/hack/go_container.sh
@@ -91,6 +91,11 @@ run_in_go_container() {
 }
 
 mkdir -p "${OUT_DIR}"
+# Temporarily change out_dir permisions to grant write access in userns-remap scenarios.
+chmod 777 "${OUT_DIR}"
 "${DOCKER}" volume inspect "${CACHE_VOLUME}" >/dev/null 2>&1 || "${DOCKER}" volume create "${CACHE_VOLUME}" >/dev/null
 detect_and_set_goos_goarch
 run_in_go_container "$@"
+# Flip write permissions back to defaults and chown generated artifacts.
+chmod 775 "${OUT_DIR}"
+sudo chown $(id -u):$(id -g) -R "${OUT_DIR}"


### PR DESCRIPTION
Sysbox runtime can either operate in 'uid-shifting' mode (if 'shiftfs' kernel module is present), or in 'non-uid-shifting' mode. For the later to work we make use of docker's userns-remap feature.

In this operational mode, we must ensure that kind-sysbox's building process can dump its artifacts in the expected 'out-dir' directory (i.e. root-repo/bin). This can only work if the building process within the container has 'write' access to out-dir. For this to work we add simple 'chmod / chown' instructions to temporarily relax write access to this folder.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>